### PR TITLE
remove scope_name because it is protected in devise

### DIFF
--- a/lib/hot_body.rb
+++ b/lib/hot_body.rb
@@ -2,7 +2,7 @@ module HotBody
 
   def body_id
     body_id = controller.class.name.sub(/Controller$/, '').sub(/::/, '').underscore+'_page'
-    body_id.sub!(/^devise_/, "devise_#{controller.scope_name}_") if body_id.match(/^devise_/)
+    body_id.sub!(/^devise_/, "devise_#{controller.devise_mapping.name}_") if body_id.match(/^devise_/)
     return body_id
   end
 


### PR DESCRIPTION
@craigulliott 

We are upgrading devise and scope_name is now protected:
https://github.com/plataformatec/devise/blob/v3.5.4/app/controllers/devise_controller.rb#L37
